### PR TITLE
Fix terminal jam when changing the resolution

### DIFF
--- a/sdk/appsrc/video_demo.c
+++ b/sdk/appsrc/video_demo.c
@@ -281,7 +281,7 @@ void DemoPrintMenu()
 	xil_printf("*                ZYBO Video Demo                 *\n\r");
 	xil_printf("**************************************************\n\r");
 	xil_printf("*Display Resolution: %28s*\n\r", dispCtrl.vMode.label);
-	printf("*Display Pixel Clock Freq. (MHz): %15.3f*\n\r", dispCtrl.pxlFreq);
+	xil_printf("*Display Pixel Clock Freq. (MHz): %11d.%03d*\n\r", (int)dispCtrl.pxlFreq, (((int)dispCtrl.pxlFreq*1000)%1000));
 	xil_printf("*Display Frame Index: %27d*\n\r", dispCtrl.curFrame);
 	if (videoCapt.state == VIDEO_DISCONNECTED) xil_printf("*Video Capture Resolution: %22s*\n\r", "!HDMI UNPLUGGED!");
 	else xil_printf("*Video Capture Resolution: %17dx%-4d*\n\r", videoCapt.timing.HActiveVideo, videoCapt.timing.VActiveVideo);
@@ -386,7 +386,7 @@ void DemoCRMenu()
 	xil_printf("*                ZYBO Video Demo                 *\n\r");
 	xil_printf("**************************************************\n\r");
 	xil_printf("*Current Resolution: %28s*\n\r", dispCtrl.vMode.label);
-	printf("*Pixel Clock Freq. (MHz): %23.3f*\n\r", dispCtrl.pxlFreq);
+	xil_printf("*Display Pixel Clock Freq. (MHz): %11d.%03d*\n\r", (int)dispCtrl.pxlFreq, (((int)dispCtrl.pxlFreq*1000)%1000));
 	xil_printf("**************************************************\n\r");
 	xil_printf("\n\r");
 	xil_printf("1 - %s\n\r", VMODE_640x480.label);


### PR DESCRIPTION
Terminal jammed in Vivado 2018.2 when trying to switch the resolution. Causes that HDMI is "unplugged" all the time and cannot show video capture in the display.

[Answer got from here](https://forum.digilentinc.com/topic/2869-zybo-hdmi-in-example-project/#comment-52323)